### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ juniper = "0.11.0"
 serde_json = "1.0.33"
 assert-json-diff = "0.2.1"
 maplit = "1.0.1"
-version-sync = "0.6"
+version-sync = "0.8"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using.