### PR TITLE
Skip query trails for fields that return enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ N/A
 
 ### Fixed
 
-N/A
+- Field methods that return enumerations no longer get `QueryTrails`. You couldn't really do anything with them since enumerations cannot contain data.
 
 ## [0.1.4] - 2019-02-16
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -848,8 +848,8 @@ mod walk_ast;
 use self::{
     parse_input::{default_error_type, parse_input},
     walk_ast::{
-        find_interface_implementors, find_special_scalar_types, gen_juniper_code, gen_query_trails,
-        Output,
+        find_enum_variants, find_interface_implementors, find_special_scalar_types,
+        gen_juniper_code, gen_query_trails, Output,
     },
 };
 use graphql_parser::parse_schema;
@@ -927,8 +927,9 @@ fn parse_and_gen_schema(schema: &str, error_type: Type) -> proc_macro::TokenStre
 
     let special_scalars = find_special_scalar_types(&doc);
     let interface_implementors = find_interface_implementors(&doc);
+    let enum_variants = find_enum_variants(&doc);
 
-    let mut output = Output::new(special_scalars, interface_implementors);
+    let mut output = Output::new(special_scalars, interface_implementors, enum_variants);
 
     gen_query_trails(&doc, &mut output);
 

--- a/src/walk_ast/find_enum_variants.rs
+++ b/src/walk_ast/find_enum_variants.rs
@@ -1,0 +1,38 @@
+use graphql_parser::query::Name;
+use graphql_parser::schema::*;
+use std::collections::HashSet;
+
+#[derive(Debug, Clone)]
+pub struct EnumVariants {
+    set: HashSet<Name>,
+}
+
+impl EnumVariants {
+    pub fn contains(&self, name: &str) -> bool {
+        self.set.contains(name)
+    }
+}
+
+pub fn find_enum_variants(doc: &Document) -> EnumVariants {
+    use graphql_parser::schema::Definition::*;
+    use graphql_parser::schema::TypeDefinition::*;
+
+    let mut out = EnumVariants {
+        set: HashSet::new(),
+    };
+
+    for def in &doc.definitions {
+        match def {
+            TypeDefinition(type_def) => match type_def {
+                Enum(enum_type) => {
+                    out.set.insert(enum_type.name.clone());
+                }
+
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    out
+}

--- a/src/walk_ast/gen_query_trails.rs
+++ b/src/walk_ast/gen_query_trails.rs
@@ -274,6 +274,7 @@ fn build_fields_map(doc: &Document) -> HashMap<NamedType, Vec<Field>> {
 mod test {
     use super::*;
     use crate::walk_ast::{
+        find_enum_variants::find_enum_variants,
         find_interface_implementors::find_interface_implementors,
         find_special_scalar_types::find_special_scalar_types,
     };
@@ -307,6 +308,7 @@ mod test {
             tokens: Vec::new(),
             special_scalars: find_special_scalar_types(&doc),
             interface_implementors: find_interface_implementors(&doc),
+            enum_variants: find_enum_variants(&doc),
         };
 
         gen_query_trails(&doc, &mut out);

--- a/tests/end_to_end_test.rs
+++ b/tests/end_to_end_test.rs
@@ -93,11 +93,7 @@ pub struct Review {
 }
 
 impl ReviewFields for Review {
-    fn field_episode<'a>(
-        &self,
-        executor: &Executor<'a, Context>,
-        _: &QueryTrail<'a, Episode, Walked>,
-    ) -> FieldResult<&Option<Episode>> {
+    fn field_episode<'a>(&self, executor: &Executor<'a, Context>) -> FieldResult<&Option<Episode>> {
         Ok(&self.episode)
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -250,7 +250,6 @@ mod enums {
         fn field_yes_no<'a>(
             &self,
             executor: &Executor<'a, Context>,
-            trail: &QueryTrail<'a, YesNo, Walked>,
             arg: Option<YesNo>,
         ) -> FieldResult<&YesNo> {
             let _: YesNo = YesNo::No;


### PR DESCRIPTION
Fixes https://github.com/davidpdrsn/juniper-from-schema/issues/22

From changelog

> Field methods that return enumerations no longer get `QueryTrails`. You couldn't really do anything with them since enumerations cannot contain data.