### PR TITLE
Use `Context` for schemes without mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ N/A
 
 ### Fixed
 
-N/A
+- Schemes that don't contain a root mutation type now doesn't fail to compile. It would use `()` for the context, when it should have used `Context`.
 
 ## [0.1.4] - 2019-02-16
 

--- a/src/walk_ast/gen_juniper_code.rs
+++ b/src/walk_ast/gen_juniper_code.rs
@@ -64,7 +64,7 @@ fn gen_schema_def(schema_def: SchemaDefinition, out: &mut Output) {
 
     let mutation = match schema_def.mutation {
         Some(mutation) => quote_ident(mutation),
-        None => quote! { juniper::EmptyMutation<()> },
+        None => quote! { juniper::EmptyMutation<Context> },
     };
 
     (quote! {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate juniper;
 
-use juniper::{Executor, FieldResult};
+use juniper::{EmptyMutation, Executor, FieldResult, Variables};
 use juniper_from_schema::{graphql_schema, graphql_schema_from_file};
 
 pub struct Context;
@@ -783,5 +783,36 @@ mod customizing_the_error_type {
         fn field_string<'a>(&self, executor: &Executor<'a, Context>) -> Result<&String, MyError> {
             unimplemented!()
         }
+    }
+}
+
+mod empty_mutations {
+    use super::*;
+
+    graphql_schema! {
+        type Query {
+            string: String!
+        }
+
+        schema { query: Query }
+    }
+
+    pub struct Query;
+
+    impl QueryFields for Query {
+        fn field_string<'a>(&self, executor: &Executor<'a, Context>) -> FieldResult<&String> {
+            unimplemented!()
+        }
+    }
+
+    fn main() {
+        let _ = juniper::execute(
+            "query Foo { string }",
+            None,
+            &Schema::new(Query, EmptyMutation::new()),
+            &Variables::new(),
+            &Context,
+        )
+        .unwrap();
     }
 }


### PR DESCRIPTION
Previously it would use `()` as the context for schemes without mutations. That didn't actually compile.

Fixes https://github.com/davidpdrsn/juniper-from-schema/issues/21