### PR TITLE
Support default values for input objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
-N/A
+- Support default values for input objects.
 
 ### Changed
 

--- a/examples/default_argument_values.rs
+++ b/examples/default_argument_values.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 #[macro_use]
 extern crate juniper;
 

--- a/examples/enumeration_types.rs
+++ b/examples/enumeration_types.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 #[macro_use]
 extern crate juniper;
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 #[macro_use]
 extern crate juniper;
 

--- a/examples/input_types.rs
+++ b/examples/input_types.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 #[macro_use]
 extern crate juniper;
 

--- a/examples/interface.rs
+++ b/examples/interface.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 #[macro_use]
 extern crate juniper;
 

--- a/examples/union_types.rs
+++ b/examples/union_types.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 #[macro_use]
 extern crate juniper;
 

--- a/src/ast_pass/ast_data_pass.rs
+++ b/src/ast_pass/ast_data_pass.rs
@@ -5,12 +5,16 @@ mod find_special_scalar_types;
 use self::find_enum_variants::{find_enum_variants, EnumVariants};
 use self::find_interface_implementors::{find_interface_implementors, InterfaceImplementors};
 use self::find_special_scalar_types::{find_special_scalar_types, SpecialScalarTypesList};
+use crate::ast_pass::type_name;
 use graphql_parser::schema::Document;
+use graphql_parser::schema::*;
+use std::collections::{HashMap, HashSet};
 
 pub struct AstData<'doc> {
     pub(super) interface_implementors: InterfaceImplementors<'doc>,
     pub(super) special_scalars: SpecialScalarTypesList<'doc>,
     pub(super) enum_variants: EnumVariants<'doc>,
+    pub(super) input_object_field_type: InputObjectFieldTypes<'doc>,
 }
 
 impl<'doc> AstData<'doc> {
@@ -18,11 +22,84 @@ impl<'doc> AstData<'doc> {
         let interface_implementors = find_interface_implementors(&doc);
         let special_scalars = find_special_scalar_types(&doc);
         let enum_variants = find_enum_variants(&doc);
+        let input_object_field_type = find_input_object_field_type(&doc);
 
         Self {
             interface_implementors,
             special_scalars,
             enum_variants,
+            input_object_field_type,
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct InputObjectFieldTypes<'a> {
+    types: HashMap<&'a str, HashMap<&'a String, &'a Type>>,
+}
+
+impl<'a> InputObjectFieldTypes<'a> {
+    pub(super) fn is_nullable(
+        &self,
+        input_type_name: &'a str,
+        field_name: &'a String,
+    ) -> Option<bool> {
+        use graphql_parser::query::Type::*;
+
+        let field_map = self.types.get(input_type_name)?;
+        let type_ = field_map.get(field_name)?;
+        match type_ {
+            NamedType(_) => Some(true),
+            ListType(_) => Some(true),
+            NonNullType(_) => Some(false),
+        }
+    }
+
+    pub(super) fn field_names(&self, input_type_name: &'a str) -> Option<HashSet<&'a &String>> {
+        let field_map = self.types.get(input_type_name)?;
+        let mut out = HashSet::new();
+        for key in field_map.keys() {
+            out.insert(key);
+        }
+        Some(out)
+    }
+
+    pub(super) fn field_type_name(
+        &self,
+        input_type_name: &'a str,
+        field_name: &'a String,
+    ) -> Option<&'a Name> {
+        let field_map = self.types.get(input_type_name)?;
+        let type_ = field_map.get(field_name)?;
+        Some(type_name(&type_))
+    }
+}
+
+fn find_input_object_field_type(doc: &Document) -> InputObjectFieldTypes {
+    use graphql_parser::schema::Definition::*;
+    use graphql_parser::schema::TypeDefinition::*;
+
+    let mut out = InputObjectFieldTypes {
+        types: HashMap::new(),
+    };
+
+    for def in &doc.definitions {
+        match def {
+            TypeDefinition(type_def) => match type_def {
+                InputObject(input_type) => {
+                    for field in &input_type.fields {
+                        out.types
+                            .entry(&input_type.name)
+                            .or_insert_with(HashMap::new)
+                            .insert(&field.name, &field.value_type);
+                    }
+                }
+
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    out
 }

--- a/src/ast_pass/code_gen_pass/gen_query_trails.rs
+++ b/src/ast_pass/code_gen_pass/gen_query_trails.rs
@@ -102,7 +102,6 @@ impl<'doc> CodeGenPass<'doc> {
         })
     }
 
-    #[allow(unused_variables)]
     fn error_msg_if_field_types_dont_overlap(
         &mut self,
         union: &'doc UnionType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -586,12 +586,8 @@
 //! - `String`
 //! - `Boolean`
 //! - Enumerations
+//! - Input objects (as field arguments, see below)
 //! - Lists containing some other supported type
-//!
-//! Input objects are currently not supported as default arguments, but might be in the future.
-//!
-//! You also cannot have `null` as the default value. In that case you might as well not have a
-//! default value.
 //!
 //! Abbreviated example (find [complete example here](https://github.com/davidpdrsn/juniper-from-schema/blob/master/examples/default_argument_values.rs)):
 //!
@@ -623,9 +619,17 @@
 //!         UNPUBLISHED
 //!     }
 //!
+//!     input Pagination {
+//!         pageSize: Int!
+//!         cursor: ID
+//!     }
+//!
 //!     type Query {
 //!         "#[ownership(owned)]"
-//!         allPosts(status: Status = PUBLISHED): [Post!]!
+//!         allPosts(
+//!             status: Status = PUBLISHED,
+//!             pagination: Pagination = { pageSize: 20 }
+//!         ): [Post!]!
 //!     }
 //!
 //!     type Post {
@@ -641,6 +645,7 @@
 //!         executor: &Executor<'_, Context>,
 //!         trail: &QueryTrail<'_, Post, Walked>,
 //!         status: Status,
+//!         pagination: Pagination,
 //!     ) -> FieldResult<Vec<Post>> {
 //!         // `status` will be `Status::Published` if not given in the query
 //!
@@ -651,6 +656,45 @@
 //!     }
 //! }
 //! ```
+//!
+//! ### Input object gotchas
+//!
+//! Defaults for input objects are only supported as field arguments. The following is not
+//! supported
+//!
+//! ```graphql
+//! input SomeType {
+//!   field: Int = 1
+//! }
+//! ```
+//!
+//! This isn't supported because [the spec is unclear about how to handle multiple nested
+//! defaults](https://github.com/webonyx/graphql-php/issues/350).
+//!
+//! Also, defaults are only used if no arguments are passed. So given the schema
+//!
+//! ```graphql
+//! input Input {
+//!   a: String
+//!   b: String
+//! }
+//!
+//! type Query {
+//!   field(arg: Input = { a: "a" }): Int!
+//! }
+//! ```
+//!
+//! and the query
+//!
+//! ```graphql
+//! query MyQuery {
+//!   field(arg: { b: "my b" })
+//! }
+//! ```
+//!
+//! The value of `arg` inside the resolver would be `Input { a: None, b: Some("my b") }`. Note that
+//! even though `a` has a default value in the field doesn't get used here because we set `arg` in
+//! the query.
 //!
 //! # GraphQL to Rust types
 //!

--- a/src/nullable_type.rs
+++ b/src/nullable_type.rs
@@ -40,7 +40,7 @@ impl<'a> NullableType<'a> {
     }
 }
 
-fn map<'a>(type_: &'a Type) -> NullableType<'a> {
+fn map(type_: &Type) -> NullableType {
     match type_ {
         inner @ Type::NamedType(_) => map_inner(inner, false),
         Type::ListType(item_type) => {
@@ -76,7 +76,6 @@ fn map_inner(type_: &Type, inside_non_null: bool) -> NullableType {
 
 #[cfg(test)]
 mod test {
-    #[allow(unused_imports)]
     use super::*;
 
     #[test]

--- a/src/parse_input.rs
+++ b/src/parse_input.rs
@@ -61,7 +61,6 @@ pub fn default_error_type() -> Type {
 
 #[cfg(test)]
 mod test {
-    #[allow(unused_imports)]
     use super::*;
 
     #[test]


### PR DESCRIPTION
https://github.com/davidpdrsn/juniper-from-schema/pull/23 didn't include support for default values for input objects. This PR adds that.

There are some gotchas around defaults set when defining the input object. You can read in the docs why they aren't supported.