### PR TITLE
Control ownership with schema directive instead of magic comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Changed
 
-N/A
+- Replace the magic `#[ownership(owned)]` comment with a schema directive.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ schema {
 }
 
 type Query {
-  // this makes the return value `FieldResult<String>`
+  // The directive makes the return value `FieldResult<String>`
   // rather than the default `FieldResult<&String>`
-  "#[ownership(owned)]"
-  helloWorld(name: String!): String!
+  helloWorld(name: String!): String! @juniper(ownership: "owned")
 }
 
 type Mutation {
@@ -208,7 +207,7 @@ returning data owned by `self` and avoids needless `.clone()` calls you would ne
 returned owned values.
 
 However if you need to return owned values (such as values queried from a database) you have to
-annotate the field in the schema with `#[ownership(owned)]`.
+add the directive `@juniper(ownership: "owned")` to the field in the schema.
 
 All field arguments will be owned.
 
@@ -274,8 +273,7 @@ graphql_schema! {
     }
 
     type Query {
-        "#[ownership(owned)]"
-        search(query: String!): [SearchResult!]!
+        search(query: String!): [SearchResult!]! @juniper(ownership: "owned")
     }
 
     interface SearchResult {
@@ -333,8 +331,7 @@ graphql_schema! {
     }
 
     type Query {
-        "#[ownership(owned)]"
-        search(query: String!): [SearchResult!]!
+        search(query: String!): [SearchResult!]! @juniper(ownership: "owned")
     }
 
     union SearchResult = Article | Tweet
@@ -386,8 +383,7 @@ graphql_schema! {
     }
 
     type Mutation {
-        "#[ownership(owned)]"
-        createPost(input: CreatePost!): Post
+        createPost(input: CreatePost!): Post @juniper(ownership: "owned")
     }
 
     input CreatePost {
@@ -446,8 +442,7 @@ graphql_schema! {
     }
 
     type Query {
-        "#[ownership(owned)]"
-        allPosts(status: Status!): [Post!]!
+        allPosts(status: Status!): [Post!]! @juniper(ownership: "owned")
     }
 
     type Post {
@@ -506,11 +501,10 @@ graphql_schema! {
     }
 
     type Query {
-        "#[ownership(owned)]"
         allPosts(
             status: Status = PUBLISHED,
             pagination: Pagination = { pageSize: 20 }
-        ): [Post!]!
+        ): [Post!]! @juniper(ownership: "owned")
     }
 
     type Post {
@@ -616,8 +610,7 @@ graphql_schema! {
     }
 
     type Query {
-        "#[ownership(owned)]"
-        allPosts: [Post!]!
+        allPosts: [Post!]! @juniper(ownership: "owned")
     }
 
     type Post {

--- a/examples/default_argument_values.rs
+++ b/examples/default_argument_values.rs
@@ -17,8 +17,7 @@ graphql_schema! {
     }
 
     type Query {
-        "#[ownership(owned)]"
-        allPosts(status: Status = PUBLISHED): [Post!]!
+        allPosts(status: Status = PUBLISHED): [Post!]! @juniper(ownership: "owned")
     }
 
     type Post {

--- a/examples/enumeration_types.rs
+++ b/examples/enumeration_types.rs
@@ -17,8 +17,7 @@ graphql_schema! {
     }
 
     type Query {
-        "#[ownership(owned)]"
-        allPosts(status: STATUS!): [Post!]!
+        allPosts(status: STATUS!): [Post!]! @juniper(ownership: "owned")
     }
 
     type Post {

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -14,10 +14,9 @@ graphql_schema! {
     }
 
     type Query {
-      // this makes the return value `FieldResult<String>`
+      // The directive makes the return value `FieldResult<String>`
       // rather than the default `FieldResult<&String>`
-      "#[ownership(owned)]"
-      helloWorld(name: String!): String!
+      helloWorld(name: String!): String! @juniper(ownership: "owned")
     }
 
     type Mutation {

--- a/examples/input_types.rs
+++ b/examples/input_types.rs
@@ -13,8 +13,7 @@ graphql_schema! {
     }
 
     type Mutation {
-        "#[ownership(owned)]"
-        createPost(input: CreatePost!): Post
+        createPost(input: CreatePost!): Post @juniper(ownership: "owned")
     }
 
     input CreatePost {

--- a/examples/interface.rs
+++ b/examples/interface.rs
@@ -12,8 +12,7 @@ graphql_schema! {
     }
 
     type Query {
-        "#[ownership(owned)]"
-        search(query: String!): [SearchResult!]!
+        search(query: String!): [SearchResult!]! @juniper(ownership: "owned")
     }
 
     interface SearchResult {

--- a/examples/query_trails.rs
+++ b/examples/query_trails.rs
@@ -18,8 +18,7 @@ graphql_schema! {
     }
 
     type Query {
-        "#[ownership(owned)]"
-        allPosts: [Post!]!
+        allPosts: [Post!]! @juniper(ownership: "owned")
     }
 
     type Post {

--- a/examples/union_types.rs
+++ b/examples/union_types.rs
@@ -12,8 +12,7 @@ graphql_schema! {
     }
 
     type Query {
-        "#[ownership(owned)]"
-        search(query: String!): [SearchResult!]!
+        search(query: String!): [SearchResult!]! @juniper(ownership: "owned")
     }
 
     union SearchResult = Article | Tweet

--- a/src/ast_pass/error.rs
+++ b/src/ast_pass/error.rs
@@ -79,6 +79,7 @@ pub enum ErrorKind<'doc> {
     UnsupportedAttributePair(&'doc str, &'doc str),
     VariableDefaultValue,
     InputTypeFieldWithDefaultValue,
+    InvalidArgumentsToDeprecateDirective,
 }
 
 impl<'doc> ErrorKind<'doc> {
@@ -118,6 +119,9 @@ impl<'doc> ErrorKind<'doc> {
             ErrorKind::InputTypeFieldWithDefaultValue => {
                 "Default values for input type fields are not supported".to_string()
             }
+            ErrorKind::InvalidArgumentsToDeprecateDirective => {
+                "Invalid arguments passed to @deprecated".to_string()
+            }
         }
     }
 
@@ -155,6 +159,9 @@ impl<'doc> ErrorKind<'doc> {
                 writeln!(f);
                 writeln!(f, "See https://github.com/webonyx/graphql-php/issues/350 for an example");
                 Some(f)
+            }
+            ErrorKind::InvalidArgumentsToDeprecateDirective => {
+                Some("It takes 0 or 1 argument and the argument most be named `reason` and be of type `String`".to_string())
             }
             _ => None,
         }

--- a/src/ast_pass/error.rs
+++ b/src/ast_pass/error.rs
@@ -75,11 +75,10 @@ pub enum ErrorKind<'doc> {
         type_b: &'doc str,
         field_type_b: &'doc str,
     },
-    UnsupportedAttribute(&'doc str),
-    UnsupportedAttributePair(&'doc str, &'doc str),
     VariableDefaultValue,
     InputTypeFieldWithDefaultValue,
     InvalidArgumentsToDeprecateDirective,
+    InvalidArgumentsToJuniperDirective,
 }
 
 impl<'doc> ErrorKind<'doc> {
@@ -101,13 +100,6 @@ impl<'doc> ErrorKind<'doc> {
             ErrorKind::NonnullableFieldWithDefaultValue => {
                 "Fields with default arguments values must be nullable".to_string()
             }
-            ErrorKind::UnsupportedAttribute(attr) => {
-                format!("The attribute {} is unsupported", attr)
-            }
-            ErrorKind::UnsupportedAttributePair(attr, value) => format!(
-                "Unsupported attribute value '{}' for attribute '{}'",
-                value, attr
-            ),
             ErrorKind::VariableDefaultValue => {
                 "Default arguments cannot refer to variables".to_string()
             }
@@ -121,6 +113,9 @@ impl<'doc> ErrorKind<'doc> {
             }
             ErrorKind::InvalidArgumentsToDeprecateDirective => {
                 "Invalid arguments passed to @deprecated".to_string()
+            }
+            ErrorKind::InvalidArgumentsToJuniperDirective => {
+                "Invalid arguments passed to @juniper".to_string()
             }
         }
     }
@@ -162,6 +157,12 @@ impl<'doc> ErrorKind<'doc> {
             }
             ErrorKind::InvalidArgumentsToDeprecateDirective => {
                 Some("It takes 0 or 1 argument and the argument most be named `reason` and be of type `String`".to_string())
+            }
+            ErrorKind::InvalidArgumentsToJuniperDirective => {
+                let mut f = String::new();
+                writeln!(f, "It takes exactly 1 argument and the argument most be named `ownership`");
+                writeln!(f, "and be either \"owned\" or \"borrowed\"");
+                Some(f)
             }
             _ => None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,9 @@
 //! }
 //!
 //! type Query {
-//!   // this makes the return value `FieldResult<String>`
+//!   // The directive makes the return value `FieldResult<String>`
 //!   // rather than the default `FieldResult<&String>`
-//!   "#[ownership(owned)]"
-//!   helloWorld(name: String!): String!
+//!   helloWorld(name: String!): String! @juniper(ownership: "owned")
 //! }
 //!
 //! type Mutation {
@@ -206,7 +205,7 @@
 //! returned owned values.
 //!
 //! However if you need to return owned values (such as values queried from a database) you have to
-//! annotate the field in the schema with `#[ownership(owned)]`.
+//! add the directive `@juniper(ownership: "owned")` to the field in the schema.
 //!
 //! All field arguments will be owned.
 //!
@@ -301,8 +300,7 @@
 //!     }
 //!
 //!     type Query {
-//!         "#[ownership(owned)]"
-//!         search(query: String!): [SearchResult!]!
+//!         search(query: String!): [SearchResult!]! @juniper(ownership: "owned")
 //!     }
 //!
 //!     interface SearchResult {
@@ -389,8 +387,7 @@
 //!     }
 //!
 //!     type Query {
-//!         "#[ownership(owned)]"
-//!         search(query: String!): [SearchResult!]!
+//!         search(query: String!): [SearchResult!]! @juniper(ownership: "owned")
 //!     }
 //!
 //!     union SearchResult = Article | Tweet
@@ -473,8 +470,7 @@
 //!     }
 //!
 //!     type Mutation {
-//!         "#[ownership(owned)]"
-//!         createPost(input: CreatePost!): Post
+//!         createPost(input: CreatePost!): Post @juniper(ownership: "owned")
 //!     }
 //!
 //!     input CreatePost {
@@ -549,8 +545,7 @@
 //!     }
 //!
 //!     type Query {
-//!         "#[ownership(owned)]"
-//!         allPosts(status: Status!): [Post!]!
+//!         allPosts(status: Status!): [Post!]! @juniper(ownership: "owned")
 //!     }
 //!
 //!     type Post {
@@ -625,11 +620,10 @@
 //!     }
 //!
 //!     type Query {
-//!         "#[ownership(owned)]"
 //!         allPosts(
 //!             status: Status = PUBLISHED,
 //!             pagination: Pagination = { pageSize: 20 }
-//!         ): [Post!]!
+//!         ): [Post!]! @juniper(ownership: "owned")
 //!     }
 //!
 //!     type Post {
@@ -742,8 +736,7 @@
 //!     }
 //!
 //!     type Query {
-//!         "#[ownership(owned)]"
-//!         allPosts: [Post!]!
+//!         allPosts: [Post!]! @juniper(ownership: "owned")
 //!     }
 //!
 //!     type Post {
@@ -1002,8 +995,7 @@ pub fn graphql_schema_from_file(input: proc_macro::TokenStream) -> proc_macro::T
 ///     }
 ///
 ///     type Query {
-///         "#[ownership(owned)]"
-///         helloWorld: String!
+///         helloWorld: String! @juniper(ownership: "owned")
 ///     }
 /// }
 ///

--- a/src/nullable_type.rs
+++ b/src/nullable_type.rs
@@ -33,7 +33,7 @@ impl<'a> NullableType<'a> {
 impl<'a> NullableType<'a> {
     fn debug_print(&self) -> String {
         match self {
-            NullableType::NamedType(name) => format!("{}", name),
+            NullableType::NamedType(name) => name.to_string(),
             NullableType::ListType(inner) => format!("List({})", inner.debug_print()),
             NullableType::NullableType(inner) => format!("Nullable({})", inner.debug_print()),
         }

--- a/tests/default_argument_values_test.rs
+++ b/tests/default_argument_values_test.rs
@@ -11,38 +11,27 @@ use std::collections::HashMap;
 
 graphql_schema! {
     type Query {
-        "#[ownership(owned)]"
-        int(arg: Int = 1): Int!
+        int(arg: Int = 1): Int! @juniper(ownership: "owned")
 
-        "#[ownership(owned)]"
-        float(arg: Float = 1.5): Float!
+        float(arg: Float = 1.5): Float! @juniper(ownership: "owned")
 
-        "#[ownership(owned)]"
-        string(arg: String = "foo"): String!
+        string(arg: String = "foo"): String! @juniper(ownership: "owned")
 
-        "#[ownership(owned)]"
-        boolean(arg: Boolean = true): Boolean!
+        boolean(arg: Boolean = true): Boolean! @juniper(ownership: "owned")
 
-        "#[ownership(owned)]"
-        list(arg: [Int!] = [1, 2, 3]): [Int!]!
+        list(arg: [Int!] = [1, 2, 3]): [Int!]! @juniper(ownership: "owned")
 
-        "#[ownership(owned)]"
-        enumeration(arg: Unit = METER): UNIT!
+        enumeration(arg: Unit = METER): UNIT! @juniper(ownership: "owned")
 
-        "#[ownership(owned)]"
-        object(arg: CoordinateIn = { lat: 1.0, long: 2.0 }): CoordinateOut!
+        object(arg: CoordinateIn = { lat: 1.0, long: 2.0 }): CoordinateOut! @juniper(ownership: "owned")
 
-        "#[ownership(owned)]"
-        objectNullable(arg: Pagination = { pageSize: null }): Int
+        objectNullable(arg: Pagination = { pageSize: null }): Int @juniper(ownership: "owned")
 
-        "#[ownership(owned)]"
-        objectNullableSet(arg: Pagination = { pageSize: 1 }): Int
+        objectNullableSet(arg: Pagination = { pageSize: 1 }): Int @juniper(ownership: "owned")
 
-        "#[ownership(owned)]"
-        objectNullablePartial(arg: A = { a: "a arg" }): [String]!
+        objectNullablePartial(arg: A = { a: "a arg" }): [String]! @juniper(ownership: "owned")
 
-        "#[ownership(owned)]"
-        objectNullableNesting(arg: B = { c: { x: 1 } }): [Int]!
+        objectNullableNesting(arg: B = { c: { x: 1 } }): [Int]! @juniper(ownership: "owned")
     }
 
     input CoordinateIn {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -480,39 +480,30 @@ mod query_trail_methods_for_interfaces {
 
     graphql_schema! {
         type Query {
-          "#[ownership(owned)]"
-          posts: [Post!]!
+          posts: [Post!]! @juniper(ownership: "owned")
         }
 
         type Post {
-          "#[ownership(owned)]"
-          comments: [Comment!]!
+          comments: [Comment!]! @juniper(ownership: "owned")
         }
 
         interface Entity {
-          "#[ownership(owned)]"
-          id: Int!
-          "#[ownership(owned)]"
-          country: Country!
+          id: Int! @juniper(ownership: "owned")
+          country: Country! @juniper(ownership: "owned")
         }
 
         type User implements Entity {
-          "#[ownership(owned)]"
-          country: Country!
-          "#[ownership(owned)]"
-          id: Int!
+          country: Country! @juniper(ownership: "owned")
+          id: Int! @juniper(ownership: "owned")
         }
 
         type Country {
-          "#[ownership(owned)]"
-          id: Int!
+          id: Int! @juniper(ownership: "owned")
         }
 
         type Comment {
-          "#[ownership(owned)]"
-          author: Entity!
-          "#[ownership(owned)]"
-          id: Int!
+          author: Entity! @juniper(ownership: "owned")
+          id: Int! @juniper(ownership: "owned")
         }
 
         schema {
@@ -606,43 +597,33 @@ mod query_trail_methods_for_union_types {
 
     graphql_schema! {
         type Query {
-          "#[ownership(owned)]"
-          posts: [Post!]!
+          posts: [Post!]! @juniper(ownership: "owned")
         }
 
         type Post {
-          "#[ownership(owned)]"
-          comments: [Comment!]!
+          comments: [Comment!]! @juniper(ownership: "owned")
         }
 
         union Entity = User | Company
 
         type User {
-          "#[ownership(owned)]"
-          country: Country!
-          "#[ownership(owned)]"
-          id: Int!
+          country: Country! @juniper(ownership: "owned")
+          id: Int! @juniper(ownership: "owned")
         }
 
         type Company {
-          "#[ownership(owned)]"
-          country_of_operation: Country!
-          "#[ownership(owned)]"
-          id: Int!
-          "#[ownership(owned)]"
-          name: String!
+          country_of_operation: Country! @juniper(ownership: "owned")
+          id: Int! @juniper(ownership: "owned")
+          name: String! @juniper(ownership: "owned")
         }
 
         type Country {
-          "#[ownership(owned)]"
-          id: Int!
+          id: Int! @juniper(ownership: "owned")
         }
 
         type Comment {
-          "#[ownership(owned)]"
-          author: Entity!
-          "#[ownership(owned)]"
-          id: Int!
+          author: Entity! @juniper(ownership: "owned")
+          id: Int! @juniper(ownership: "owned")
         }
 
         schema {
@@ -808,5 +789,25 @@ mod empty_mutations {
             &Context,
         )
         .unwrap();
+    }
+}
+
+mod ownership_with_directives {
+    use super::*;
+
+    graphql_schema! {
+        type Query {
+            string: String! @juniper(ownership: "owned")
+        }
+
+        schema { query: Query }
+    }
+
+    pub struct Query;
+
+    impl QueryFields for Query {
+        fn field_string<'a>(&self, executor: &Executor<'a, Context>) -> FieldResult<String> {
+            unimplemented!()
+        }
     }
 }

--- a/tests/schemas/complex_schema.graphql
+++ b/tests/schemas/complex_schema.graphql
@@ -9,16 +9,13 @@ schema {
 
 "The query type, represents all of the entry points into our object graph"
 type Query {
-  "#[ownership(owned)]"
-  hero(episode: Episode): Character
-  "#[ownership(owned)]"
-  search(text: String): [SearchResult!]
+  hero(episode: Episode): Character @juniper(ownership: "owned")
+  search(text: String): [SearchResult!] @juniper(ownership: "owned")
 }
 
 "The mutation type, represents all updates we can make to our data"
 type Mutation {
-  "#[ownership(owned)]"
-  createReview(episode: Episode, review: ReviewInput!): Review
+  createReview(episode: Episode, review: ReviewInput!): Review @juniper(ownership: "owned")
 }
 
 "The episodes in the Star Wars trilogy"
@@ -35,9 +32,8 @@ enum Episode {
 interface Character {
   """
   The ID of the character
-  #[ownership(owned)]
   """
-  id: ID!
+  id: ID! @juniper(ownership: "owned")
   "The name of the character"
   name: String!
 }
@@ -46,9 +42,8 @@ interface Character {
 type Human implements Character {
   """
   The ID of the human
-  #[ownership(owned)]
   """
-  id: ID!
+  id: ID! @juniper(ownership: "owned")
   "What this human calls themselves"
   name: String!
 }
@@ -57,9 +52,8 @@ type Human implements Character {
 type Droid implements Character {
   """
   The ID of the human
-  #[ownership(owned)]
   """
-  id: ID!
+  id: ID! @juniper(ownership: "owned")
   "What this human calls themselves"
   name: String!
 }

--- a/tests/schemas/doc_schema.graphql
+++ b/tests/schemas/doc_schema.graphql
@@ -4,8 +4,7 @@ schema {
 }
 
 type Query {
-  "#[ownership(owned)]"
-  helloWorld(name: String!): String!
+  helloWorld(name: String!): String! @juniper(ownership: "owned")
 }
 
 type Mutation {

--- a/tests/schemas/ownership_attributes.graphql
+++ b/tests/schemas/ownership_attributes.graphql
@@ -1,17 +1,13 @@
 type Query {
   """
   Some other comment
-
-  #[ownership(borrowed)]
   """
-  borrowed_string: String!
+  borrowed_string: String! @juniper(ownership: "borrowed")
 
   """
   Some other comment
-
-  #[ownership(owned)]
   """
-  owned_string: String!
+  owned_string: String! @juniper(ownership: "owned")
 }
 
 schema {

--- a/tests/schemas/returning_references.graphql
+++ b/tests/schemas/returning_references.graphql
@@ -1,17 +1,14 @@
 type Query {
-  "#[ownership(owned)]"
-  userNonNull(id: Int!): User!
+  userNonNull(id: Int!): User! @juniper(ownership: "owned")
 
-  "#[ownership(owned)]"
-  userNullable(id: Int!): User
+  userNullable(id: Int!): User @juniper(ownership: "owned")
 }
 
 type User {
   id: Int!
   nameNonNull: String!
 
-  "#[ownership(owned)]"
-  nameNullable: String
+  nameNullable: String @juniper(ownership: "owned")
 }
 
 schema {


### PR DESCRIPTION
Fixes https://github.com/davidpdrsn/juniper-from-schema/issues/27

I decided to go ahead and implement this using the directive `@juniper(ownership: "owned|borrowed")`. We can always change that later. But this version seemed the most future proof.

@LegNeato what do you think?