### PR TITLE
Fix QueryTrail walk failing on snake_case fields

### DIFF
--- a/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass/gen_query_trails.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass/gen_query_trails.rs
@@ -1,7 +1,7 @@
 use super::{ident, type_name, CodeGenPass, TypeKind};
 use crate::ast_pass::error::ErrorKind;
 use graphql_parser::schema::*;
-use heck::{CamelCase, SnakeCase, MixedCase};
+use heck::{CamelCase, MixedCase, SnakeCase};
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::collections::{HashMap, HashSet};

--- a/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass/gen_query_trails.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass/gen_query_trails.rs
@@ -1,7 +1,7 @@
 use super::{ident, type_name, CodeGenPass, TypeKind};
 use crate::ast_pass::error::ErrorKind;
 use graphql_parser::schema::*;
-use heck::{CamelCase, SnakeCase};
+use heck::{CamelCase, SnakeCase, MixedCase};
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::collections::{HashMap, HashSet};
@@ -138,7 +138,7 @@ impl<'doc> CodeGenPass<'doc> {
         match ty {
             TypeKind::Scalar => {
                 let name = ident(&field.name.to_snake_case());
-                let string_name = &field.name;
+                let string_name = &field.name.to_mixed_case();
 
                 quote! {
                     /// Check if a scalar leaf node is queried for
@@ -155,7 +155,7 @@ impl<'doc> CodeGenPass<'doc> {
             }
             TypeKind::Type => {
                 let name = ident(&field.name.to_snake_case());
-                let string_name = &field.name;
+                let string_name = &field.name.to_mixed_case();
 
                 quote! {
                     /// Walk the trail into a field.


### PR DESCRIPTION
Long story short, juniper turns snake_case names in a schema (e.g.
`app_users`) into mixedCase (e.g. `appUsers`). This is currently not
mirrored by the generated QueryTrail code, resulting in the field walk
methods always returning `None` even though the field was actually
requested.

The relevant piece of code in juniper: https://github.com/graphql-rust/juniper/blob/master/juniper_codegen/src/derive_object.rs#L48

As the codegen is already using `heck`, the solution is just to always
convert the field name to mixedCase like juniper.

(It's a little confusing, because hecks camel case is actually pascal
case, and the mixed case is what's traditionally called pascal case)