### PR TITLE
Split definition into different modules

### DIFF
--- a/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass.rs
@@ -406,7 +406,7 @@ impl<'doc> SchemaVisitor<'doc> for CodeGenPass<'doc> {
                 quote! {
                     #[allow(missing_docs)]
                     #description
-                    #name: #rust_type
+                    pub #name: #rust_type
                 }
             })
             .collect::<Vec<_>>();

--- a/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass/gen_query_trails.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass/gen_query_trails.rs
@@ -14,7 +14,7 @@ impl<'doc> CodeGenPass<'doc> {
         let fields_map = build_fields_map(doc);
 
         for def in &doc.definitions {
-            if self.is_with_ident(def) {
+            if self.check_with_ident(def) {
                 if let Definition::TypeDefinition(type_def) = def {
                     match type_def {
                         TypeDefinition::Object(obj) => {

--- a/juniper-from-schema-code-gen/src/ast_pass/schema_visitor.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/schema_visitor.rs
@@ -1,15 +1,21 @@
 use graphql_parser::schema;
 
 pub trait SchemaVisitor<'doc> {
+    fn is_with_ident(&self, def: &'doc schema::Definition) -> bool {
+        true
+    }
+
     fn visit_document(&mut self, doc: &'doc schema::Document) {
         use graphql_parser::schema::Definition::*;
 
         for def in &doc.definitions {
-            match def {
-                SchemaDefinition(inner) => self.visit_schema_definition(inner),
-                TypeDefinition(inner) => self.visit_type_definition(inner),
-                TypeExtension(inner) => self.visit_type_extension(inner),
-                DirectiveDefinition(inner) => self.visit_directive_definition(inner),
+            if self.is_with_ident(def) {
+                match def {
+                    SchemaDefinition(inner) => self.visit_schema_definition(inner),
+                    TypeDefinition(inner) => self.visit_type_definition(inner),
+                    TypeExtension(inner) => self.visit_type_extension(inner),
+                    DirectiveDefinition(inner) => self.visit_directive_definition(inner),
+                }
             }
         }
     }

--- a/juniper-from-schema-code-gen/src/ast_pass/schema_visitor.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/schema_visitor.rs
@@ -1,7 +1,7 @@
 use graphql_parser::schema;
 
 pub trait SchemaVisitor<'doc> {
-    fn is_with_ident(&self, def: &'doc schema::Definition) -> bool {
+    fn check_with_ident(&mut self, def: &'doc schema::Definition) -> bool {
         true
     }
 
@@ -9,7 +9,7 @@ pub trait SchemaVisitor<'doc> {
         use graphql_parser::schema::Definition::*;
 
         for def in &doc.definitions {
-            if self.is_with_ident(def) {
+            if self.check_with_ident(def) {
                 match def {
                     SchemaDefinition(inner) => self.visit_schema_definition(inner),
                     TypeDefinition(inner) => self.visit_type_definition(inner),

--- a/juniper-from-schema-code-gen/src/lib.rs
+++ b/juniper-from-schema-code-gen/src/lib.rs
@@ -18,7 +18,8 @@ use self::{
 };
 use graphql_parser::parse_schema;
 use proc_macro2::TokenStream;
-use syn::{Ident, Type};
+use std::collections::BTreeMap;
+use syn::Type;
 
 /// Read a GraphQL schema file and generate corresponding Juniper macro calls.
 ///
@@ -77,7 +78,7 @@ pub fn graphql_schema(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 fn parse_and_gen_schema(
     schema: &str,
     error_type: Type,
-    with_idents: Option<Vec<Ident>>,
+    with_idents: Option<BTreeMap<String, bool>>,
 ) -> proc_macro::TokenStream {
     let doc = match parse_schema(&schema) {
         Ok(doc) => doc,
@@ -90,7 +91,6 @@ fn parse_and_gen_schema(
     match output.gen_juniper_code(&doc) {
         Ok(tokens) => {
             let out: proc_macro::TokenStream = tokens.into();
-
             if debugging_enabled() {
                 self::pretty_print::code_gen_debug(out.to_string());
             }

--- a/juniper-from-schema-code-gen/src/parse_input.rs
+++ b/juniper-from-schema-code-gen/src/parse_input.rs
@@ -1,14 +1,35 @@
 use std::path::PathBuf;
 use syn::{
-    self,
+    self, bracketed,
     parse::{Parse, ParseStream},
-    Token, Type,
+    punctuated::Punctuated,
+    Ident, Token, Type,
 };
+
+struct VecIdent(Vec<Ident>);
+
+impl Parse for VecIdent {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        let b = bracketed!(content in input);
+        let punc = Punctuated::<Ident, Token![,]>::parse_terminated(&content)?;
+        let vec: Vec<Ident> = punc.into_iter().map(|t| t).collect();
+        if vec.len() == 0 {
+            Err(syn::parse::Error::new(
+                b.span,
+                "argument `with_idents` should have at least one element",
+            ))
+        } else {
+            Ok(VecIdent(vec))
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct GraphqlSchemaFromFileInput {
     pub schema_path: PathBuf,
     pub error_type: Type,
+    pub with_idents: Option<Vec<Ident>>,
 }
 
 impl Parse for GraphqlSchemaFromFileInput {
@@ -19,32 +40,61 @@ impl Parse for GraphqlSchemaFromFileInput {
         let pwd = PathBuf::from(cargo_dir);
         let schema_path = pwd.join(file);
 
-        let error_type = if input.peek(Token![,]) {
+        let mut error_type: Option<Type> = None;
+        let mut with_idents: Option<VecIdent> = None;
+
+        while input.peek(Token![,]) {
             input.parse::<Token![,]>()?;
-            let ident = input.parse::<syn::Ident>()?;
-            if ident != "error_type" {
-                return Err(syn::parse::Error::new(
-                    ident.span(),
-                    "expected `error_type`",
-                ));
+            if !input.is_empty() {
+                let ident = input.parse::<syn::Ident>()?;
+                match ident.to_string().as_ref() {
+                    "error_type" => {
+                        parse_optional_arg(&mut error_type, &input, &ident)?;
+                    }
+                    "with_idents" => {
+                        parse_optional_arg(&mut with_idents, &input, &ident)?;
+                    }
+                    _ => {
+                        return Err(syn::parse::Error::new(
+                            ident.span(),
+                            "expected `error_type` or `with_idents`",
+                        ));
+                    }
+                }
             }
-            input.parse::<Token![:]>()?;
-            input.parse::<Type>()?
-        } else {
-            default_error_type()
-        };
+        }
 
         if input.peek(Token![,]) {
             input.parse::<Token![,]>()?;
         }
 
+        let error_type = error_type.unwrap_or_else(|| default_error_type());
+        let with_idents = with_idents.map(|t| t.0);
         Ok(GraphqlSchemaFromFileInput {
             schema_path,
             error_type,
+            with_idents,
         })
     }
 }
 
 pub fn default_error_type() -> Type {
     syn::parse_str("juniper::FieldError").expect("Failed to parse default error type")
+}
+
+fn parse_optional_arg<T: Parse>(
+    value: &mut Option<T>,
+    input: &ParseStream,
+    ident: &Ident,
+) -> syn::Result<()> {
+    input.parse::<Token![:]>()?;
+    if value.is_none() {
+        *value = Some(input.parse::<T>()?);
+        Ok(())
+    } else {
+        Err(syn::parse::Error::new(
+            ident.span(),
+            "duplicate argument definition",
+        ))
+    }
 }

--- a/juniper-from-schema/tests/compile_fail/wrong_with_ident_value.rs
+++ b/juniper-from-schema/tests/compile_fail/wrong_with_ident_value.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code, unused_variables, unused_must_use, unused_imports)]
+include!("../setup.rs");
+
+use juniper::ID;
+
+graphql_schema_from_file!(
+    "../../../juniper-from-schema/tests/schemas/complex_schema.graphql",
+    error_type: MyError,
+    with_idents: [WrongIdent]
+);

--- a/juniper-from-schema/tests/compile_fail/wrong_with_ident_value.stderr
+++ b/juniper-from-schema/tests/compile_fail/wrong_with_ident_value.stderr
@@ -1,0 +1,18 @@
+error: proc macro panicked
+  --> $DIR/wrong_with_ident_value.rs:6:1
+   |
+6  | / graphql_schema_from_file!(
+7  | |     "../../../juniper-from-schema/tests/schemas/complex_schema.graphql",
+8  | |     error_type: MyError,
+9  | |     with_idents: [WrongIdent]
+10 | | );
+   | |__^
+   |
+   = help: message: 
+           
+           [91merror[0m: Identity `WrongIdent` is not found in schema
+           
+           Each value in `with_ident` must be in the schema.
+           
+           
+           aborting due to previous error

--- a/juniper-from-schema/tests/compile_pass/customizing_the_error_type.rs
+++ b/juniper-from-schema/tests/compile_pass/customizing_the_error_type.rs
@@ -1,5 +1,15 @@
 #![allow(dead_code, unused_variables, unused_must_use, unused_imports)]
-include!("../setup.rs");
+
+// Note: Avoid using setup.rs to make sure that the code isn't generated with juniper::FieldResult
+
+use juniper::Executor;
+
+use juniper_from_schema::graphql_schema_from_file;
+
+pub struct Context;
+impl juniper::Context for Context {}
+
+fn main() {}
 
 graphql_schema_from_file!(
     "../../../juniper-from-schema/tests/schemas/very_simple_schema.graphql",

--- a/juniper-from-schema/tests/compile_pass/with_idents.rs
+++ b/juniper-from-schema/tests/compile_pass/with_idents.rs
@@ -5,8 +5,8 @@ use juniper::ID;
 
 graphql_schema_from_file!(
     "../../../juniper-from-schema/tests/schemas/complex_schema.graphql",
+    with_idents: [Character, Droid, Human],
     error_type: MyError,
-    with_idents: [Character, Droid, Human]
 );
 
 pub enum MyError {

--- a/juniper-from-schema/tests/compile_pass/with_idents.rs
+++ b/juniper-from-schema/tests/compile_pass/with_idents.rs
@@ -1,0 +1,42 @@
+#![allow(dead_code, unused_variables, unused_must_use, unused_imports)]
+include!("../setup.rs");
+
+use juniper::ID;
+
+graphql_schema_from_file!(
+    "../../../juniper-from-schema/tests/schemas/complex_schema.graphql",
+    error_type: MyError,
+    with_idents: [Character, Droid, Human]
+);
+
+pub enum MyError {
+    Foo,
+    Bar,
+}
+impl juniper::IntoFieldError for MyError {
+    fn into_field_error(self) -> juniper::FieldError {
+        unimplemented!()
+    }
+}
+
+pub struct Human { }
+
+impl HumanFields for Human {
+    fn field_id<'a>(&self, executor: &Executor<'a, Context>) -> Result<ID, MyError> {
+        unimplemented!()
+    }
+    fn field_name<'a>(&self, executor: &Executor<'a, Context>) -> Result<&String, MyError> {
+        unimplemented!()
+    }
+}
+
+pub struct Droid { }
+
+impl DroidFields for Droid {
+    fn field_id<'a>(&self, executor: &Executor<'a, Context>) -> Result<ID, MyError> {
+        unimplemented!()
+    }
+    fn field_name<'a>(&self, executor: &Executor<'a, Context>) -> Result<&String, MyError> {
+        unimplemented!()
+    }
+}

--- a/juniper-from-schema/tests/split_mod_test.rs
+++ b/juniper-from-schema/tests/split_mod_test.rs
@@ -1,0 +1,329 @@
+#![allow(dead_code, unused_variables, unused_imports)]
+
+#[macro_use]
+extern crate juniper;
+#[macro_use]
+extern crate maplit;
+
+use assert_json_diff::assert_json_include;
+use juniper::{Executor, FieldResult, Variables, ID};
+use juniper_from_schema::{graphql_schema, graphql_schema_from_file};
+use serde_json::{self, json, Value};
+
+use std::collections::HashMap;
+
+pub struct Context {
+    db: Db,
+}
+
+impl juniper::Context for Context {}
+
+struct Db {
+    humans: HashMap<&'static str, character::Human>,
+}
+
+mod input {
+    use super::*;
+
+    graphql_schema_from_file!(
+        "tests/schemas/complex_schema.graphql",
+        with_idents: [ColorInput, ReviewInput]
+    );
+}
+
+mod character {
+    use super::*;
+
+    graphql_schema_from_file!(
+        "tests/schemas/complex_schema.graphql",
+        with_idents: [Human, Droid, Character]
+    );
+
+    #[derive(Clone)]
+    pub struct Human {
+        pub id: &'static str,
+        pub name: String,
+    }
+
+    impl HumanFields for Human {
+        fn field_id<'a>(&self, executor: &Executor<'a, Context>) -> FieldResult<ID> {
+            Ok(ID::new(self.id))
+        }
+
+        fn field_name<'a>(&self, executor: &Executor<'a, Context>) -> FieldResult<&String> {
+            Ok(&self.name)
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Droid {
+        id: &'static str,
+        name: String,
+    }
+
+    impl DroidFields for Droid {
+        fn field_id<'a>(&self, executor: &Executor<'a, Context>) -> FieldResult<ID> {
+            Ok(ID::new(self.id))
+        }
+
+        fn field_name<'a>(&self, executor: &Executor<'a, Context>) -> FieldResult<&String> {
+            Ok(&self.name)
+        }
+    }
+}
+
+mod episode {
+    use super::*;
+    graphql_schema_from_file!(
+        "tests/schemas/complex_schema.graphql",
+        with_idents: [Episode]
+    );
+}
+
+mod search_result {
+    use super::*;
+    use character::{Droid, Human};
+
+    graphql_schema_from_file!(
+        "tests/schemas/complex_schema.graphql",
+        with_idents: [SearchResult]
+    );
+}
+
+mod review {
+    use super::*;
+    use episode::Episode;
+    use input::ColorInput;
+
+    graphql_schema_from_file!(
+        "tests/schemas/complex_schema.graphql",
+        with_idents: [Review]
+    );
+
+    pub struct Review {
+        pub episode: Option<Episode>,
+        pub stars: i32,
+        pub commentary: Option<String>,
+        pub favorite_color: Option<ColorInput>,
+    }
+
+    impl ReviewFields for Review {
+        fn field_episode<'a>(
+            &self,
+            executor: &Executor<'a, Context>,
+        ) -> FieldResult<&Option<Episode>> {
+            Ok(&self.episode)
+        }
+
+        fn field_stars<'a>(&self, executor: &Executor<'a, Context>) -> FieldResult<&i32> {
+            Ok(&self.stars)
+        }
+
+        fn field_commentary<'a>(
+            &self,
+            executor: &Executor<'a, Context>,
+        ) -> FieldResult<&Option<String>> {
+            Ok(&self.commentary)
+        }
+
+        fn field_favorite_color<'a>(
+            &self,
+            executor: &Executor<'a, Context>,
+            _: &QueryTrail<'a, ColorInput, Walked>,
+        ) -> FieldResult<&Option<ColorInput>> {
+            Ok(&self.favorite_color)
+        }
+    }
+
+}
+
+mod query {
+    use super::*;
+    use character::Character;
+    use episode::Episode;
+    use search_result::SearchResult;
+
+    graphql_schema_from_file!("tests/schemas/complex_schema.graphql", with_idents: [Query]);
+
+    pub struct Query;
+
+    impl QueryFields for Query {
+        fn field_hero<'a>(
+            &self,
+            executor: &Executor<'a, Context>,
+            trail: &QueryTrail<'a, Character, Walked>,
+            episode: Option<Episode>,
+        ) -> FieldResult<Option<Character>> {
+            let hero = episode.and_then(|episode| {
+                let luke = executor
+                    .context()
+                    .db
+                    .humans
+                    .get(&"1")
+                    .map(|h| Character::from(h.clone()));
+
+                match episode {
+                    Episode::Newhope => luke,
+                    Episode::Empire => luke,
+                    Episode::Jedi => luke,
+                }
+            });
+
+            Ok(hero)
+        }
+
+        fn field_search<'a>(
+            &self,
+            executor: &Executor<'a, Context>,
+            trail: &QueryTrail<'a, SearchResult, Walked>,
+            text: Option<String>,
+        ) -> FieldResult<Option<Vec<SearchResult>>> {
+            let results = text.map(|text| {
+                executor
+                    .context()
+                    .db
+                    .humans
+                    .clone()
+                    .into_iter()
+                    .map(|(_, human)| human)
+                    .filter(|human| human.name.contains(&text))
+                    .map(SearchResult::from)
+                    .collect::<Vec<_>>()
+            });
+            Ok(results)
+        }
+    }
+}
+
+mod mutation {
+    use super::*;
+    use episode::Episode;
+    use review::Review;
+    use input::ReviewInput;
+
+    graphql_schema_from_file!(
+        "tests/schemas/complex_schema.graphql",
+        with_idents: [Mutation]
+    );
+
+    pub struct Mutation;
+
+    impl MutationFields for Mutation {
+        fn field_create_review<'a>(
+            &self,
+            executor: &Executor<'a, Context>,
+            trail: &QueryTrail<'a, Review, Walked>,
+            episode: Option<Episode>,
+            review: ReviewInput,
+        ) -> FieldResult<Option<Review>> {
+            let review = Review {
+                episode,
+                stars: review.stars,
+                commentary: review.commentary,
+                favorite_color: review.favorite_color,
+            };
+
+            // the fact that everything type checks is test enough, we don't need to actually insert
+            // this review
+
+            Ok(Some(review))
+        }
+    }
+}
+
+use query::Query;
+use mutation::Mutation;
+
+graphql_schema_from_file!(
+    "tests/schemas/complex_schema.graphql",
+    with_idents: [schema]
+);
+
+#[test]
+fn query_hero() {
+    let value = run_query(r#"query { hero(episode: NEWHOPE) { id name } }"#);
+
+    assert_json_include!(
+        actual: value,
+        expected: json!({
+            "hero": {
+                "id": "1",
+                "name": "Luke Skywalker",
+            }
+        })
+    );
+
+    let value = run_query(r#"query { hero(episode: EMPIRE) { id name } }"#);
+
+    assert_json_include!(
+        actual: value,
+        expected: json!({
+            "hero": {
+                "id": "1",
+                "name": "Luke Skywalker",
+            }
+        })
+    );
+
+    let value = run_query(r#"query { hero(episode: JEDI) { id name } }"#);
+
+    assert_json_include!(
+        actual: value,
+        expected: json!({
+            "hero": {
+                "id": "1",
+                "name": "Luke Skywalker",
+            }
+        })
+    );
+}
+
+#[test]
+fn search() {
+    let value = run_query(
+        r#"
+        query {
+            search(text: "Luke") {
+                ... on Human {
+                    id name
+                }
+                ... on Droid {
+                    id name
+                }
+            }
+        }
+        "#,
+    );
+
+    assert_json_include!(
+        actual: value,
+        expected: json!({
+            "search": [
+                { "id": "1", "name": "Luke Skywalker" },
+            ]
+        })
+    );
+}
+
+fn run_query(query: &str) -> Value {
+    use character::Human;
+
+    let db = Db {
+        humans: hashmap! {
+            "1" => Human { id: "1", name: "Luke Skywalker".to_string() },
+        },
+    };
+
+    let ctx = Context { db };
+
+    let (res, _errors) = juniper::execute(
+        query,
+        None,
+        &Schema::new(Query, Mutation),
+        &Variables::new(),
+        &ctx,
+    )
+    .unwrap();
+
+    serde_json::from_str(&serde_json::to_string(&res).unwrap()).unwrap()
+}

--- a/juniper-from-schema/tests/split_mod_test.rs
+++ b/juniper-from-schema/tests/split_mod_test.rs
@@ -134,7 +134,6 @@ mod review {
             Ok(&self.favorite_color)
         }
     }
-
 }
 
 mod query {
@@ -198,8 +197,8 @@ mod query {
 mod mutation {
     use super::*;
     use episode::Episode;
-    use review::Review;
     use input::ReviewInput;
+    use review::Review;
 
     graphql_schema_from_file!(
         "tests/schemas/complex_schema.graphql",
@@ -231,8 +230,8 @@ mod mutation {
     }
 }
 
-use query::Query;
 use mutation::Mutation;
+use query::Query;
 
 graphql_schema_from_file!(
     "tests/schemas/complex_schema.graphql",


### PR DESCRIPTION
issue #60

Add a new optional argument `with_idents` for `graphql_schema_from_file!`. The usage is as fallowing:
```rust
graphql_schema_from_file!(
    "tests/schemas/complex_schema.graphql",
    with_idents: [Character, Droid, Human]
);
pub struct Human { }
impl HumanFields for Human {
    /* implementation */
}
pub struct Droid { }
impl DroidFields for Droid {
    /* implementation */
}
// Character is a graphql interface, hence no need to implement it.
```

tests suits:
1. tests/compile_pass/with_idents.rs
2. tests/compile_fail/wrong_with_ident_value.rs
3. tests/split_mod_test.rs

p,s. Some test suits have already failed since I forked them, don't know if I should fix them.

