### PR TITLE
Allow down casting query trail interface and union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
-N/A
+- Support converting `QueryTrail`s for interfaces or unions into `QueryTrail`s for implementors of those interfaces or unions. This makes it possible to use [juniper-eager-loading](https://crates.io/crates/juniper-eager-loading) with interface or union types. [#63](https://github.com/davidpdrsn/juniper-from-schema/pull/63)
 
 ### Changed
 

--- a/juniper-from-schema-code-gen/src/ast_pass/ast_data_pass.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/ast_data_pass.rs
@@ -10,6 +10,7 @@ use graphql_parser::{
 };
 use std::collections::{BTreeSet, HashMap, HashSet};
 
+#[derive(Debug)]
 pub struct AstData<'doc> {
     interface_implementors: HashMap<&'doc str, Vec<&'doc str>>,
     user_scalars: HashSet<&'doc str>,

--- a/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass.rs
@@ -29,6 +29,7 @@ use syn::Ident;
 
 type Result<T, E = ()> = std::result::Result<T, E>;
 
+#[derive(Debug)]
 pub struct CodeGenPass<'doc> {
     tokens: TokenStream,
     error_type: syn::Type,

--- a/juniper-from-schema/tests/converting_query_trails_test.rs
+++ b/juniper-from-schema/tests/converting_query_trails_test.rs
@@ -1,0 +1,159 @@
+#![allow(dead_code, unused_variables, unused_must_use, unused_imports)]
+use juniper::{EmptyMutation, Executor, FieldResult, Variables};
+use juniper_from_schema::{graphql_schema, graphql_schema_from_file};
+
+pub struct Context;
+impl juniper::Context for Context {}
+
+graphql_schema! {
+    type Query {
+      entities: [Entity!]! @juniper(ownership: "owned")
+      search(query: String!): [SearchResult!]! @juniper(ownership: "owned")
+    }
+
+    interface Entity {
+      id: Int! @juniper(ownership: "owned")
+      name: String!
+    }
+
+    type User implements Entity {
+      id: Int! @juniper(ownership: "owned")
+      name: String!
+    }
+
+    union SearchResult = User
+
+    schema {
+      query: Query
+    }
+}
+
+pub struct Query;
+
+impl QueryFields for Query {
+    fn field_entities<'a>(
+        &self,
+        executor: &Executor<'a, Context>,
+        trail: &QueryTrail<'a, Entity, Walked>,
+    ) -> FieldResult<Vec<Entity>> {
+        verify_entity_query_trail(trail);
+        verify_user_query_trail(&trail.into());
+
+        Ok(vec![])
+    }
+
+    fn field_search<'a>(
+        &self,
+        executor: &Executor<'a, Context>,
+        trail: &QueryTrail<'a, SearchResult, Walked>,
+        _query: String,
+    ) -> FieldResult<Vec<SearchResult>> {
+        verify_search_result_query_trail(trail);
+        verify_user_query_trail(&trail.into());
+
+        Ok(vec![])
+    }
+}
+
+fn verify_entity_query_trail<'a>(trail: &QueryTrail<'a, Entity, Walked>) {
+    if !trail.id() {
+        panic!("Entity.id missing from trail")
+    }
+}
+
+fn verify_search_result_query_trail<'a>(trail: &QueryTrail<'a, SearchResult, Walked>) {
+    if !trail.id() {
+        panic!("id missing from trail")
+    }
+}
+
+fn verify_user_query_trail<'a>(trail: &QueryTrail<'a, User, Walked>) {
+    if !trail.id() {
+        panic!("User.id missing from trail")
+    }
+}
+
+pub struct User {
+    id: i32,
+    name: String,
+}
+
+impl UserFields for User {
+    fn field_id<'a>(&self, executor: &Executor<'a, Context>) -> FieldResult<i32> {
+        Ok(self.id)
+    }
+
+    fn field_name<'a>(&self, executor: &Executor<'a, Context>) -> FieldResult<&String> {
+        Ok(&self.name)
+    }
+}
+
+#[test]
+fn test_converting_interface_trails() {
+    query(
+        r#"
+        query {
+            entities {
+                id
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_converting_interface_trails_negative() {
+    query(
+        r#"
+        query {
+            entities {
+                name
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn test_converting_union_trails() {
+    query(
+        r#"
+        query {
+            search(query: "foo") {
+                ... on User {
+                    id
+                }
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_converting_union_trails_negative() {
+    query(
+        r#"
+        query {
+            search(query: "foo") {
+                ... on User {
+                    name
+                }
+            }
+        }
+        "#,
+    );
+}
+
+fn query(query: &str) {
+    let ctx = Context;
+    let (juniper_value, _errors) = juniper::execute(
+        query,
+        None,
+        &Schema::new(Query, juniper::EmptyMutation::new()),
+        &Variables::new(),
+        &ctx,
+    )
+    .unwrap();
+}


### PR DESCRIPTION
This is part of fixing
https://github.com/davidpdrsn/juniper-eager-loading/issues/15.

In order to perform eager loading on a `Vec<User>` you need to know
which associations are being queried. The `QueryTrail<User, _>` type has
that information.

However, this doesn't work for interfaces since if you have an interface
called for example `Entity` you will not get a `QueryTrail<User, _>` but
instead a `QueryTrail<Entity, _>`. That doesn't work to eager load
users, which means you cannot eager at all. This is because `Entity` is
an enum with a variant for each type that implements that interface.

With this change we also generate implementations of `Into` for
`QueryTrail<Entity, _>` into each type that implements it. That allows
you get a `QueryTrail<User, _>` to do eager loading with.

---

TODO:
 - [x] Test that actually eager loads association and uses the associations QueryTrail
 - [x] Update docs