### PR TITLE
Fix support for custom scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 - Internal refactoring of input parsing. Shouldn't be a breaking change but should provide better error messages.
 - Internal refactoring of code generation. Use visitor trait for `CodeGenPass`.
 - Implement common traits for generated scalar types.
+- Special case scalars `Date`, `DateTime`, `Uuid`, and `Url` no longer support descriptions in the GraphQL schema. See [#69](https://github.com/davidpdrsn/juniper-from-schema/pull/69) for more details.
 
 ### Removed
 
@@ -22,7 +23,7 @@ N/A
 
 ### Fixed
 
-N/A
+- Fix support for special case [`Uuid`](https://crates.io/crates/uuid) and [`Url`](https://crates.io/crates/url) scalars. [#69](https://github.com/davidpdrsn/juniper-from-schema/pull/69)
 
 ## [0.3.0] - 2019-06-18
 

--- a/juniper-from-schema-code-gen/src/ast_pass/ast_data_pass.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/ast_data_pass.rs
@@ -72,6 +72,10 @@ impl<'doc> AstData<'doc> {
         self.is_scalar("Uuid")
     }
 
+    pub fn url_scalar_defined(&self) -> bool {
+        self.is_scalar("Url")
+    }
+
     pub fn is_scalar(&self, name: &str) -> bool {
         self.special_scalars.contains(name)
     }

--- a/juniper-from-schema-code-gen/src/ast_pass/ast_data_pass.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/ast_data_pass.rs
@@ -68,6 +68,10 @@ impl<'doc> AstData<'doc> {
         self.is_scalar("DateTime")
     }
 
+    pub fn uuid_scalar_defined(&self) -> bool {
+        self.is_scalar("Uuid")
+    }
+
     pub fn is_scalar(&self, name: &str) -> bool {
         self.special_scalars.contains(name)
     }

--- a/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass.rs
@@ -67,6 +67,7 @@ impl<'doc> SchemaVisitor<'doc> for CodeGenPass<'doc> {
         match &*scalar_type.name {
             "Date" => {}
             "DateTime" => {}
+            "Uuid" => {}
             name => {
                 let name = ident(name);
                 let description = &scalar_type
@@ -480,6 +481,10 @@ impl<'doc> CodeGenPass<'doc> {
 
     pub fn is_date_scalar_defined(&self) -> bool {
         self.ast_data.date_scalar_defined()
+    }
+
+    pub fn is_uuid_scalar_defined(&self) -> bool {
+        self.ast_data.uuid_scalar_defined()
     }
 
     pub fn is_scalar(&self, name: &str) -> bool {
@@ -979,6 +984,16 @@ impl<'doc> CodeGenPass<'doc> {
                 }
                 (
                     quote! { chrono::DateTime<chrono::offset::Utc> },
+                    TypeKind::Scalar,
+                )
+            }
+            "Uuid" => {
+                if !self.is_uuid_scalar_defined() {
+                    self.emit_fatal_error(pos, ErrorKind::UuidScalarNotDefined)
+                        .ok();
+                }
+                (
+                    quote! { uuid::Uuid },
                     TypeKind::Scalar,
                 )
             }

--- a/juniper-from-schema-code-gen/src/ast_pass/error.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/error.rs
@@ -63,6 +63,8 @@ pub enum ErrorKind<'doc> {
     DateTimeScalarNotDefined,
     DateScalarNotDefined,
     UuidScalarNotDefined,
+    UrlScalarNotDefined,
+    SpecialCaseScalarWithDescription,
     DirectivesNotSupported,
     NoQueryType,
     NonnullableFieldWithDefaultValue,
@@ -95,6 +97,12 @@ impl<'doc> ErrorKind<'doc> {
             }
             ErrorKind::UuidScalarNotDefined => {
                 "You have to define a custom scalar called `Uuid` to use this type".to_string()
+            }
+            ErrorKind::UrlScalarNotDefined => {
+                "You have to define a custom scalar called `Url` to use this type".to_string()
+            }
+            ErrorKind::SpecialCaseScalarWithDescription => {
+                "Special case scalars don't support having descriptions because the Rust types are defined in external crates".to_string()
             }
             ErrorKind::DirectivesNotSupported => {
                 "Directives are currently not supported".to_string()

--- a/juniper-from-schema-code-gen/src/ast_pass/error.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/error.rs
@@ -62,6 +62,7 @@ impl<'a> fmt::Display for Error<'a> {
 pub enum ErrorKind<'doc> {
     DateTimeScalarNotDefined,
     DateScalarNotDefined,
+    UuidScalarNotDefined,
     DirectivesNotSupported,
     NoQueryType,
     NonnullableFieldWithDefaultValue,
@@ -91,6 +92,9 @@ impl<'doc> ErrorKind<'doc> {
             }
             ErrorKind::DateScalarNotDefined => {
                 "You have to define a custom scalar called `Date` to use this type".to_string()
+            }
+            ErrorKind::UuidScalarNotDefined => {
+                "You have to define a custom scalar called `Uuid` to use this type".to_string()
             }
             ErrorKind::DirectivesNotSupported => {
                 "Directives are currently not supported".to_string()

--- a/juniper-from-schema/Cargo.toml
+++ b/juniper-from-schema/Cargo.toml
@@ -23,3 +23,4 @@ maplit = "1.0.1"
 version-sync = "0.8"
 trybuild = "1.0.3"
 rustversion = "0.1"
+uuid = { version = "0.7.4", features = ["v4"] }

--- a/juniper-from-schema/Cargo.toml
+++ b/juniper-from-schema/Cargo.toml
@@ -23,4 +23,5 @@ maplit = "1.0.1"
 version-sync = "0.8"
 trybuild = "1.0.3"
 rustversion = "0.1"
-uuid = { version = "0.7.4", features = ["v4"] }
+uuid = { version = "^0.7.4", features = ["v4"] }
+url = "^1.5.1"

--- a/juniper-from-schema/tests/compile_fail/docs_on_special_case_scalars.rs
+++ b/juniper-from-schema/tests/compile_fail/docs_on_special_case_scalars.rs
@@ -1,0 +1,34 @@
+#![allow(dead_code, unused_variables, unused_must_use, unused_imports)]
+include!("../setup.rs");
+
+use url::Url;
+
+graphql_schema! {
+    schema {
+        query: Query
+    }
+
+    type Query {
+        foo: String! @juniper(ownership: "owned")
+    }
+
+    "Url docs"
+    scalar Url
+
+    "DateTime docs"
+    scalar DateTime
+
+    "Date docs"
+    scalar Date
+
+    "Uuid docs"
+    scalar Uuid
+}
+
+pub struct Query;
+
+impl QueryFields for Query {
+    fn field_foo(&self, _: &Executor<'_, Context>) -> FieldResult<String> {
+        unimplemented!()
+    }
+}

--- a/juniper-from-schema/tests/compile_fail/docs_on_special_case_scalars.stderr
+++ b/juniper-from-schema/tests/compile_fail/docs_on_special_case_scalars.stderr
@@ -1,0 +1,46 @@
+error: proc macro panicked
+  --> $DIR/docs_on_special_case_scalars.rs:6:1
+   |
+6  | / graphql_schema! {
+7  | |     schema {
+8  | |         query: Query
+9  | |     }
+...  |
+25 | |     scalar Uuid
+26 | | }
+   | |_^
+   |
+   = help: message: 
+           
+           [91merror[0m: Special case scalars don't support having descriptions because the Rust types are defined in external crates
+            --> schema:2:63
+             |
+           2 |    { foo : String ! @ juniper (ownership : "owned") } "Url docs" scalar Url
+             |                                                                  [91m^[0m
+           
+           
+           [91merror[0m: Special case scalars don't support having descriptions because the Rust types are defined in external crates
+            --> schema:3:17
+             |
+           3 |    "DateTime docs" scalar DateTime "Date docs" scalar Date "Uuid docs" scalar
+             |                    [91m^[0m
+           
+           
+           [91merror[0m: Special case scalars don't support having descriptions because the Rust types are defined in external crates
+            --> schema:3:45
+             |
+           3 |    "DateTime docs" scalar DateTime "Date docs" scalar Date "Uuid docs" scalar
+             |                                                [91m^[0m
+           
+           
+           [91merror[0m: Special case scalars don't support having descriptions because the Rust types are defined in external crates
+            --> schema:3:69
+             |
+           3 |    "DateTime docs" scalar DateTime "Date docs" scalar Date "Uuid docs" scalar
+             |                                                                        [91m^[0m
+           
+           
+           aborting due to 4 errors
+           
+
+error: Could not compile `juniper-from-schema-tests`.

--- a/juniper-from-schema/tests/compile_pass/url.rs
+++ b/juniper-from-schema/tests/compile_pass/url.rs
@@ -1,0 +1,25 @@
+#![allow(dead_code, unused_variables, unused_must_use, unused_imports)]
+include!("../setup.rs");
+
+use url::Url;
+
+graphql_schema! {
+    schema {
+        query: Query
+    }
+
+    type Query {
+        url: Url! @juniper(ownership: "owned")
+    }
+
+    scalar Url
+}
+
+pub struct Query;
+
+impl QueryFields for Query {
+    fn field_url(&self, _: &Executor<'_, Context>) -> FieldResult<Url> {
+        let url = Url::parse("https://example.com").unwrap();
+        Ok(url)
+    }
+}

--- a/juniper-from-schema/tests/compile_pass/uuid.rs
+++ b/juniper-from-schema/tests/compile_pass/uuid.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code, unused_variables, unused_must_use, unused_imports)]
+include!("../setup.rs");
+
+use uuid::Uuid;
+
+graphql_schema! {
+    schema {
+        query: Query
+    }
+
+    type Query {
+        uuid: Uuid! @juniper(ownership: "owned")
+    }
+
+    scalar Uuid
+}
+
+pub struct Query;
+
+impl QueryFields for Query {
+    fn field_uuid(&self, _: &Executor<'_, Context>) -> FieldResult<Uuid> {
+        Ok(Uuid::new_v4())
+    }
+}

--- a/juniper-from-schema/tests/doc_test.rs
+++ b/juniper-from-schema/tests/doc_test.rs
@@ -125,7 +125,7 @@ graphql_schema! {
         queryField(
             "queryFieldArg desc"
             queryFieldArg: InputType!
-        ): Url!
+        ): SomeScalar!
 
         "deprecatedField desc"
         deprecatedField: ID! @deprecated
@@ -138,8 +138,8 @@ graphql_schema! {
         search(query: String!): [SearchResult!]!
     }
 
-    "Url scalar desc"
-    scalar Url
+    "SomeScalar scalar desc"
+    scalar SomeScalar
 
     "InputType desc"
     input InputType {
@@ -175,7 +175,11 @@ graphql_schema! {
 pub struct Query;
 
 impl QueryFields for Query {
-    fn field_query_field<'a>(&self, _: &Executor<'a, Context>, _: InputType) -> FieldResult<&Url> {
+    fn field_query_field<'a>(
+        &self,
+        _: &Executor<'a, Context>,
+        _: InputType,
+    ) -> FieldResult<&SomeScalar> {
         unimplemented!()
     }
 
@@ -299,11 +303,11 @@ fn test_docs() {
                     "name": "SearchResult",
                     "description": "SearchResult desc",
                 },
-                { "name": "String" },
                 {
-                    "name": "Url",
-                    "description": "Url scalar desc",
+                    "name": "SomeScalar",
+                    "description": "SomeScalar scalar desc",
                 },
+                { "name": "String" },
                 { "name": "User" },
                 {
                     "name": "UserType",


### PR DESCRIPTION
Juniper has builtin support for a few special case scalar types. We already have support for Date and DateTime (through [chrono](https://crates.io/crates/chrono)), but [Uuid](https://crates.io/crates/uuid) and [Url](https://crates.io/crates/url) weren't supported properly. This fixes that.

---

Regarding [Url](https://crates.io/crates/url), [juniper](https://crates.io/crates/juniper) currently depends on version `^1.5.1` however the latest version is `2.1.0`. So if you see an error like

```
the trait `juniper::executor::IntoResolvable<'_, _, _, _>` is not implemented for `std::result::Result<url::Url, juniper::executor::FieldError>`
```

That is most likely because you're not using version `^1.5.1` of [Url](https://crates.io/crates/url).

@LegNeato I'm not quite sure if this is intentional or an oversight.

---

I also noticed that these special case scalar types previously supported having descriptions in the GraphQL schema. However since the corresponding Rust types lives in other crates, we cannot add that description on the Rust side. So those descriptions wouldn't be used. I find that surprising and I think it should be an error. It will now be.

---

Fixes https://github.com/davidpdrsn/juniper-from-schema/issues/68