### PR TITLE
Remove use of deprecated `juniper::graphql_object!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ N/A
 ### Fixed
 
 - Fix support for special case [`Uuid`](https://crates.io/crates/uuid) and [`Url`](https://crates.io/crates/url) scalars. [#69](https://github.com/davidpdrsn/juniper-from-schema/pull/69)
+- Replace use deprecated `juniper::graphql_object` macro with `juniper::object` proc macro.
 
 ## [0.3.0] - 2019-06-18
 


### PR DESCRIPTION
Fixes #55

This isn't complete yet. This patch currently removes support for having
descriptions on field arguments. That is because getting those to work
[requires funky stuff][funky] in the juniper proc macro invocation.

While it could totally be made to work I would rather wait since it
requires a bit of refactoring and since it should work seamlessly once
[RFC 2564](https://github.com/rust-lang/rust/issues/60406) is stable,
which seems to happen in 1.39.

[funky]: https://docs.rs/juniper_codegen/0.13.2/juniper_codegen/attr.object.html#customization-documentation-renaming-

---

Blocked by https://github.com/graphql-rust/juniper/issues/421