### PR TITLE
Don't deprecate enum variants in Rust code when marked as deprecated in the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 - Support customizing the name of the context type. [#66](https://github.com/davidpdrsn/juniper-from-schema/pull/66)
 - Improve documentation of special case scalar types.
+- Implement common traits for generated scalar types.
 
 ### Changed
 
-- Internal refactoring of input parsing. Shouldn't be a breaking change but should provide better error messages.
-- Internal refactoring of code generation. Use visitor trait for `CodeGenPass`.
-- Implement common traits for generated scalar types.
 - Special case scalars `Date`, `DateTime`, `Uuid`, and `Url` no longer support descriptions in the GraphQL schema. See [#69](https://github.com/davidpdrsn/juniper-from-schema/pull/69) for more details.
-- Refactor schema directive parsing. Should give better error messages and be more flexible in the future.
 
 ### Removed
 
@@ -28,6 +25,9 @@ N/A
 - Fix support for special case [`Uuid`](https://crates.io/crates/uuid) and [`Url`](https://crates.io/crates/url) scalars. [#69](https://github.com/davidpdrsn/juniper-from-schema/pull/69)
 - Removed some deprecation warnings related to scalar types. [#78](https://github.com/davidpdrsn/juniper-from-schema/pull/78)
 - Don't deprecate enum variants in Rust code when marked as deprecated in the schema.
+- Internal refactoring of input parsing. Shouldn't be a breaking change but should provide better error messages.
+- Internal refactoring of code generation. Use visitor trait for `CodeGenPass`.
+- Refactor schema directive parsing. Should give better error messages and be more flexible in the future.
 
 ## [0.3.0] - 2019-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ N/A
 
 - Fix support for special case [`Uuid`](https://crates.io/crates/uuid) and [`Url`](https://crates.io/crates/url) scalars. [#69](https://github.com/davidpdrsn/juniper-from-schema/pull/69)
 - Removed some deprecation warnings related to scalar types. [#78](https://github.com/davidpdrsn/juniper-from-schema/pull/78)
+- Don't deprecate enum variants in Rust code when marked as deprecated in the schema.
 
 ## [0.3.0] - 2019-06-18
 

--- a/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass.rs
@@ -773,12 +773,21 @@ impl<'doc> CodeGenPass<'doc> {
         let name = to_enum_name(&graphql_name);
         let description = doc_tokens(&enum_value.description);
 
-        let deprecation = quote_deprecation(&self.parse_directives(enum_value));
+        let graphql_attr = match self.parse_directives(enum_value) {
+            Deprecation::NoDeprecation => {
+                quote! { #[graphql(name=#graphql_name)] }
+            }
+            Deprecation::Deprecated(None) => {
+                quote! { #[graphql(name=#graphql_name, deprecated="")] }
+            }
+            Deprecation::Deprecated(Some(reason)) => {
+                quote! { #[graphql(name=#graphql_name, deprecated=#reason)] }
+            }
+        };
 
         quote! {
             #[allow(missing_docs)]
-            #[graphql(name=#graphql_name)]
-            #deprecation
+            #graphql_attr
             #description
             #name,
         }

--- a/juniper-from-schema/tests/doc_test.rs
+++ b/juniper-from-schema/tests/doc_test.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "128"]
 #![allow(dead_code)]
+#![deny(deprecated)]
 
 extern crate juniper;
 extern crate maplit;
@@ -270,7 +271,7 @@ fn test_docs() {
                         {
                             "name": "OTHER",
                             "description": "OTHER desc",
-                            "deprecationReason": null,
+                            "deprecationReason": "",
                             "isDeprecated": true,
                         },
                     ],


### PR DESCRIPTION
Fixes https://github.com/davidpdrsn/juniper-from-schema/issues/72