### PR TITLE
Remove unused dependencies

### DIFF
--- a/juniper-from-schema-code-gen/Cargo.toml
+++ b/juniper-from-schema-code-gen/Cargo.toml
@@ -18,8 +18,6 @@ quote = "1.0.2"
 graphql-parser = "0.2.2"
 proc-macro2 = "1.0.5"
 heck = "0.3.0"
-regex = "1.1.0"
-lazy_static = "1.1.0"
 rustfmt-nightly = { version = "1.0.1", optional = true }
 colored = "1.8.0"
 


### PR DESCRIPTION
Fixes https://github.com/davidpdrsn/juniper-from-schema/issues/87

Removes regex and lazy_static dependencies since they were no longer being used.

Also runs `cargo udeps` on CI so unused dependencies should be caught in the future.