### PR TITLE
Support Rust keywords in the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 ## Unreleased
 
 - Support making fields infallible with `@juniper(infallible: true)`.
+- Support Rust keywords in the schema using [raw identifies](https://doc.rust-lang.org/stable/edition-guide/rust-2018/module-system/raw-identifiers.html). [#93](https://github.com/davidpdrsn/juniper-from-schema/pull/93).
 
 #### Breaking changes
 

--- a/juniper-from-schema-code-gen/src/ast_pass.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass.rs
@@ -2,18 +2,25 @@ pub mod ast_data_pass;
 pub mod code_gen_pass;
 pub mod directive_parsing;
 pub mod error;
+mod is_keyword;
 pub mod schema_visitor;
 
 pub use self::{code_gen_pass::CodeGenPass, error::ErrorKind};
-use graphql_parser::Pos;
 
-use graphql_parser::{query::Name, schema::Type};
-use proc_macro2::{Span, TokenStream};
-use quote::quote;
+use graphql_parser::{query::Name, schema::Type, Pos};
+use is_keyword::is_keyword;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 use syn::{self, Ident};
 
 pub fn ident<T: AsRef<str>>(name: T) -> Ident {
-    Ident::new(name.as_ref(), Span::call_site())
+    let r = name.as_ref();
+
+    if is_keyword(r) {
+        format_ident!("r#{}", r)
+    } else {
+        format_ident!("{}", r)
+    }
 }
 
 // TODO: `Name` is a type alias for `String`. It would be nice if this returned a newtype so we

--- a/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass.rs
@@ -788,8 +788,6 @@ impl<'doc> CodeGenPass<'doc> {
     }
 
     fn collect_data_for_field_gen(&mut self, field: &'doc Field) -> FieldTokens<'doc> {
-        let name = ident(&field.name);
-
         let inner_type = type_name(&field.field_type).to_camel_case();
 
         let attributes = self.parse_directives(field);
@@ -806,7 +804,7 @@ impl<'doc> CodeGenPass<'doc> {
             field.position,
         );
 
-        let field_method = ident(format!("field_{}", name.to_string().to_snake_case()));
+        let field_method = ident(format!("field_{}", field.name.to_snake_case()));
 
         let args_data = field
             .arguments
@@ -851,7 +849,7 @@ impl<'doc> CodeGenPass<'doc> {
             .collect::<Vec<_>>();
 
         FieldTokens {
-            name,
+            name: ident(&field.name),
             macro_args,
             trait_args,
             field_type,

--- a/juniper-from-schema-code-gen/src/ast_pass/is_keyword.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/is_keyword.rs
@@ -1,0 +1,12 @@
+pub fn is_keyword(s: &str) -> bool {
+    KEYWORDS.contains(&s)
+}
+
+// https://doc.rust-lang.org/reference/keywords.html
+static KEYWORDS: [&str; 53] = [
+    "Self", "abstract", "as", "async", "await", "become", "box", "break", "const", "continue",
+    "crate", "do", "dyn", "dyn", "else", "enum", "extern", "false", "final", "fn", "for", "if",
+    "impl", "in", "let", "loop", "macro", "match", "mod", "move", "mut", "override", "priv", "pub",
+    "ref", "return", "self", "static", "struct", "super", "trait", "true", "try", "type", "typeof",
+    "union", "unsafe", "unsized", "use", "virtual", "where", "while", "yield",
+];

--- a/juniper-from-schema/src/lib.rs
+++ b/juniper-from-schema/src/lib.rs
@@ -22,6 +22,7 @@
 //!     - [Customizing ownership](#customizing-ownership)
 //!     - [Infallible fields](#infallible-fields)
 //! - [GraphQL to Rust types](#graphql-to-rust-types)
+//! - [When you schema contains Rust keywords](#when-you-schema-contains-rust-keywords)
 //! - [Query trails](#query-trails)
 //!     - [Abbreviated example](#abbreviated-example)
 //!     - [Types](#types)
@@ -835,6 +836,25 @@
 //! - `String` -> `String`
 //! - `Boolean` -> `bool`
 //! - `ID` -> [`juniper::ID`](https://docs.rs/juniper/latest/juniper/struct.ID.html)
+//!
+//! # When you schema contains Rust keywords
+//!
+//! If your schema contains Rust keywords such as:
+//!
+//! ```graphql
+//! type User {
+//!     // `type` is a keyword in Rust
+//!     type: UserType!
+//! }
+//! ```
+//!
+//! [raw identifies][] will be used instead. So in this case `r#type` would be used for
+//! corresponding method generated on `Query<User, _>`. You would have to call it as `trail.r#type()`
+//!
+//! The things considered keywords can be found
+//! [here](https://doc.rust-lang.org/reference/keywords.html).
+//!
+//! [raw identifies]: https://doc.rust-lang.org/stable/edition-guide/rust-2018/module-system/raw-identifiers.html
 //!
 //! # Query trails
 //!

--- a/juniper-from-schema/tests/compile_pass/keywords_in_schema.rs
+++ b/juniper-from-schema/tests/compile_pass/keywords_in_schema.rs
@@ -1,0 +1,20 @@
+#![allow(dead_code, unused_variables, unused_must_use, unused_imports)]
+include!("setup.rs");
+
+juniper_from_schema::graphql_schema! {
+    schema {
+        query: Query
+    }
+
+    type Query {
+        type: String!
+    }
+}
+
+pub struct Query;
+
+impl QueryFields for Query {
+    fn field_type(&self, _: &Executor<'_, Context>, _: String) -> FieldResult<&String> {
+        unimplemented!()
+    }
+}

--- a/juniper-from-schema/tests/compile_pass/keywords_in_schema.rs
+++ b/juniper-from-schema/tests/compile_pass/keywords_in_schema.rs
@@ -1,5 +1,11 @@
 #![allow(dead_code, unused_variables, unused_must_use, unused_imports)]
-include!("setup.rs");
+
+use juniper::{EmptyMutation, Executor, FieldResult, Variables};
+use serde_json::Value;
+
+pub struct Context;
+
+impl juniper::Context for Context {}
 
 juniper_from_schema::graphql_schema! {
     schema {
@@ -7,14 +13,43 @@ juniper_from_schema::graphql_schema! {
     }
 
     type Query {
-        type: String!
+        type(fn: Input!): [String!]! @juniper(ownership: "owned")
+    }
+
+    input Input {
+        struct: String!
     }
 }
 
 pub struct Query;
 
 impl QueryFields for Query {
-    fn field_type(&self, _: &Executor<'_, Context>, _: String) -> FieldResult<&String> {
-        unimplemented!()
+    fn field_type(&self, _: &Executor<'_, Context>, input: Input) -> FieldResult<Vec<String>> {
+        Ok(vec![input.r#struct])
     }
+}
+
+fn main() {
+    let (juniper_value, _errors) = juniper::execute(
+        r#"
+        query Test {
+            type(fn: { struct: "value" })
+        }"#,
+        None,
+        &Schema::new(Query, juniper::EmptyMutation::new()),
+        &Variables::new(),
+        &Context,
+    )
+    .unwrap_or_else(|e| {
+        let json = serde_json::to_string_pretty(&e).unwrap();
+        panic!("{}", json)
+    });
+
+    let json: Value =
+        serde_json::from_str(&serde_json::to_string(&juniper_value).unwrap()).unwrap();
+
+    assert_json_diff::assert_json_include!(
+        actual: json,
+        expected: serde_json::json!({ "type": ["value"] })
+    );
 }


### PR DESCRIPTION
[Raw identifies](https://doc.rust-lang.org/stable/edition-guide/rust-2018/module-system/raw-identifiers.html) will be used.

Fixes https://github.com/davidpdrsn/juniper-from-schema/issues/92.