### PR TITLE
Provide _opt methods for args to allow them to be ommitted

### DIFF
--- a/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass/gen_query_trails.rs
+++ b/juniper-from-schema-code-gen/src/ast_pass/code_gen_pass/gen_query_trails.rs
@@ -662,7 +662,7 @@ impl<'pass, 'doc> QueryTrailCodeGenPass<'pass, 'doc> {
                 pub fn #opt_ident(&self) -> Option<#field_type> {
                     use juniper::LookAheadMethods;
 
-                    let arg = if let Some(lh) = &self.0.look_head.flat_map(|lh| lh.select_child(#field_name)) {
+                    let arg = if let Some(lh) = &self.0.look_ahead.and_then(|lh| lh.select_child(#field_name)) {
                         lh.arguments().iter().find(|arg| {
                             arg.name() == #name
                         })
@@ -670,12 +670,13 @@ impl<'pass, 'doc> QueryTrailCodeGenPass<'pass, 'doc> {
                         None
                     };
 
-                    if let Some(arg) = arg {
+                    let r = if let Some(arg) = arg {
                         let value = arg.value();
                         FromLookAheadValue::<#field_type>::from(value)
                     } else {
                         #default_value
-                    }
+                    };
+                    Some(r)
                 }
             }
         } else {
@@ -702,11 +703,11 @@ impl<'pass, 'doc> QueryTrailCodeGenPass<'pass, 'doc> {
                 pub fn #opt_ident(&self) -> Option<#field_type> {
                     use juniper::LookAheadMethods;
 
-                    if let Some(lh) = &self.0.look_head.flat_map(|lh| lh.select_child(#field_name)) {
+                    if let Some(lh) = &self.0.look_ahead.and_then(|lh| lh.select_child(#field_name)) {
                         let arg = lh.arguments().iter().find(|arg| {
                             arg.name() == #name
                         });
-                        arg.flat_map(|arg| {
+                        arg.map(|arg| {
                             let value = arg.value();
                             FromLookAheadValue::<#field_type>::from(value)
                         })

--- a/juniper-from-schema/tests/query_trail_arguments.rs
+++ b/juniper-from-schema/tests/query_trail_arguments.rs
@@ -85,7 +85,7 @@ impl QueryFields for Query {
         trail: &QueryTrail<'_, A, Walked>,
     ) -> FieldResult<A> {
         if let Some(c) = trail.b().c().walk() {
-            if opt_check {
+            if self.0 {
                 assert_eq!(None, c.field_with_arg_args().nullable_arg2());
             } else {
                 assert_eq!(

--- a/juniper-from-schema/tests/query_trail_arguments.rs
+++ b/juniper-from-schema/tests/query_trail_arguments.rs
@@ -76,7 +76,7 @@ graphql_schema! {
     scalar DateTimeUtc
 }
 
-pub struct Query;
+pub struct Query(bool);
 
 impl QueryFields for Query {
     fn field_a(
@@ -85,12 +85,16 @@ impl QueryFields for Query {
         trail: &QueryTrail<'_, A, Walked>,
     ) -> FieldResult<A> {
         if let Some(c) = trail.b().c().walk() {
+            if opt_check {
+                assert_eq!(None, c.field_with_arg_args().nullable_arg2());
+            } else {
+                assert_eq!(
+                    Some("bar".to_string()),
+                    c.field_with_arg_args().nullable_arg2()
+                );
+            }
             assert_eq!("foo".to_string(), c.field_with_arg_args().string_arg());
             assert_eq!(None, c.field_with_arg_args().nullable_arg());
-            assert_eq!(
-                Some("bar".to_string()),
-                c.field_with_arg_args().nullable_arg2()
-            );
             assert_eq!(1, c.field_with_arg_args().int_arg());
             assert_eq!("2.5", c.field_with_arg_args().float_arg().to_string());
             assert_eq!(false, c.field_with_arg_args().bool_arg());
@@ -241,7 +245,49 @@ fn scalar_values() {
                 }
             }
         }
-    }"#,
+    }"#, false,
+    );
+    assert_json_include!(
+        actual: value,
+        expected: json!({
+            "a": { "b": { "c": {} } }
+        })
+    );
+}
+
+#[test]
+fn scalar_values_opt() {
+    let value = run_query(
+        r#"query {
+        a {
+            b {
+                c {
+                    fieldWithArg(
+                        stringArg: "foo",
+                        nullableArg: null,
+                        intArg: 1,
+                        floatArg: 2.5,
+                        boolArg: false,
+                        listArg: [1, 2, 3],
+                        enumArg: RED,
+                        objectArg: { value: "baz" },
+                        cursorArg: "cursor-value",
+                        idArg: "id-value",
+                        urlArg: "https://example.net",
+                        uuidArg: "46ebd0ee-0e6d-43c9-b90d-ccc35a913f3e",
+                        dateArg: "2019-01-01",
+                        dateTimeArg: "1996-12-19T16:39:57-08:00",
+                        defaultArg2: "value set in query",
+                    )
+                    fieldWithArgReturningType(
+                        stringArg: "qux",
+                    ) {
+                      value
+                    }
+                }
+            }
+        }
+    }"#, true,
     );
     assert_json_include!(
         actual: value,
@@ -253,11 +299,11 @@ fn scalar_values() {
 
 type Context = ();
 
-fn run_query(query: &str) -> Value {
+fn run_query(query: &str, opt_check: bool) -> Value {
     let (res, _errors) = juniper::execute(
         query,
         None,
-        &Schema::new(Query, juniper::EmptyMutation::new()),
+        &Schema::new(Query(opt_check), juniper::EmptyMutation::new()),
         &Variables::new(),
         &(),
     )


### PR DESCRIPTION
Provides _opt method for accessing arguments that are nullable. They will return an option rather than panic'ing if not present.