### PR TITLE
[#137] Add support for multiple schema files

### DIFF
--- a/juniper-from-schema-build-tests/file/build.rs
+++ b/juniper-from-schema-build-tests/file/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    juniper_from_schema_build::configure_for_file("schema.graphql")
+    juniper_from_schema_build::configure_for_files(vec!["schema/*.graphql"])
         .context_type("()")
         .error_type("MyError")
         .compile()

--- a/juniper-from-schema-build-tests/file/schema/schema1.graphql
+++ b/juniper-from-schema-build-tests/file/schema/schema1.graphql
@@ -3,5 +3,5 @@ schema {
 }
 
 type Query {
-    ping: Boolean!
+    foo: Foo
 }

--- a/juniper-from-schema-build-tests/file/schema/schema2.graphql
+++ b/juniper-from-schema-build-tests/file/schema/schema2.graphql
@@ -1,0 +1,3 @@
+type Foo {
+    ping: Boolean!
+}

--- a/juniper-from-schema-code-gen/Cargo.toml
+++ b/juniper-from-schema-code-gen/Cargo.toml
@@ -19,6 +19,7 @@ graphql-parser = "0.3"
 proc-macro2 = "1"
 heck = "0.3"
 colored = "1.8"
+glob = "0.3"
 
 [dev_dependencies]
 version-sync = "0.8"

--- a/juniper-from-schema-proc-macro/src/lib.rs
+++ b/juniper-from-schema-proc-macro/src/lib.rs
@@ -21,7 +21,7 @@ use parse_input::GraphqlSchemaFromFileInput;
 #[proc_macro]
 pub fn graphql_schema_from_file(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let GraphqlSchemaFromFileInput {
-        schema_path,
+        schema_paths,
         context_type,
         error_type,
     } = match syn::parse::<GraphqlSchemaFromFileInput>(input) {
@@ -29,7 +29,7 @@ pub fn graphql_schema_from_file(input: proc_macro::TokenStream) -> proc_macro::T
         Err(e) => return e.to_compile_error().into(),
     };
 
-    let mut builder = CodeGen::build_from_schema_file(schema_path);
+    let mut builder = CodeGen::build_from_schema_files(schema_paths);
     if let Some(context_type) = context_type {
         builder = builder.context_type(context_type);
     }

--- a/juniper-from-schema-proc-macro/src/parse_input.rs
+++ b/juniper-from-schema-proc-macro/src/parse_input.rs
@@ -7,7 +7,7 @@ use syn::{
 
 #[derive(Debug)]
 pub struct GraphqlSchemaFromFileInput {
-    pub schema_path: PathBuf,
+    pub schema_paths: Vec<PathBuf>,
     pub error_type: Option<Type>,
     pub context_type: Option<Type>,
 }
@@ -56,7 +56,9 @@ impl Parse for GraphqlSchemaFromFileInput {
         }
 
         Ok(GraphqlSchemaFromFileInput {
-            schema_path,
+            // Only supporting single paths for macro, since long term we're
+            // moving towards the build.rs style
+            schema_paths: vec![schema_path],
             error_type,
             context_type,
         })


### PR DESCRIPTION
Users can now pass multiple schema paths, and schema paths can also be glob patterns. All the schema files will simple be concatenated together, then parsing/codegen will continue like normal.

I didn't bother adding support for multiple paths in the proc macro, because I couldn't figure out the parsing. I figured since that format is on its way out, plus it will still get support for glob patterns, it wasn't super necessary.

Fixes #137 